### PR TITLE
fixed Mimosa26 pixel pitch

### DIFF
--- a/models/pixeldetector.xml
+++ b/models/pixeldetector.xml
@@ -12,20 +12,20 @@
 <npix_y>576</npix_y>
 <npix_z>0</npix_z>
 
-<pixsize_x units="um">9.25</pixsize_x>
-<pixsize_y units="um">9.25</pixsize_y>
+<pixsize_x units="um">9.2</pixsize_x>
+<pixsize_y units="um">9.2</pixsize_y>
 <pixsize_z units="um">25.</pixsize_z>
 
-<chip_hx units="um">10656.0</chip_hx>
-<chip_hy units="um">5328.0</chip_hy>
+<chip_hx units="um">10598.4</chip_hx>
+<chip_hy units="um">5299.2</chip_hy>
 <chip_hz units="um">0.0</chip_hz>
 
 <chip_posx units="um">0.</chip_posx>
 <chip_posy units="um">0.</chip_posy>
 <chip_posz units="um">0.</chip_posz>
 
-<sensor_hx units="um">10656.0</sensor_hx>
-<sensor_hy units="um">5328.0</sensor_hy>
+<sensor_hx units="um">10598.4</sensor_hx>
+<sensor_hy units="um">5299.2</sensor_hy>
 <sensor_hz units="um">25.0</sensor_hz>
 
 <sensor_gr_excess_htop units="um">375.0</sensor_gr_excess_htop>


### PR DESCRIPTION
Mimosa26 detectors have an 18.4 um pixel pitch, see chapter 1.1 (page 4) of:
http://www.iphc.cnrs.fr/IMG/pdf/M26_UserManual_light.pdf
