### PR TITLE
Eu tel conv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,28 @@ else()
         message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
+#----------------------------------------------------------------------------
+# In case the EUTelescoep converter should be built, we need LCIO 
+#
+option(BUILD_EUTELCONV "Compile Python EUDAQ binding library?" OFF)
+IF(BUILD_EUTELCONV)
 
-include_directories(/work1/Kilian.Lohmann/ILCSOFT/v01-17-09/lcio/v02-07/include)
-link_directories(/work1/Kilian.Lohmann/ILCSOFT/v01-17-09/lcio/v02-07/lib)
-add_executable(EUTelConverter share/EUTelConverter/RootFileConverter.cc ${sources} ${headers} )
-target_link_libraries(EUTelConverter ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} lcio)
+	FIND_PACKAGE( ILCUTIL COMPONENTS ILCSOFT_CMAKE_MODULES REQUIRED ILCTEST)
+
+	# load default settings from ILCSOFT_CMAKE_MODULES
+	INCLUDE( ilcsoft_default_settings )
+
+	FIND_PACKAGE( LCIO REQUIRED ) 
+
+	INCLUDE_DIRECTORIES(SYSTEM ${LCIO_INCLUDE_DIRS} )
+    LINK_LIBRARIES( ${LCIO_LIBRARIES} )
+    message(STATUS ${LCIO_LIBRARIES} )
+	ADD_DEFINITIONS ( ${LCIO_DEFINITIONS} )
+
+	add_executable(EUTelConverter share/EUTelConverter/RootFileConverter.cc ${sources} ${headers} )
+	target_link_libraries(EUTelConverter ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} )
+	install(TARGETS EUTelConverter DESTINATION bin)
+ENDIF()
 
 
 #----------------------------------------------------------------------------
@@ -132,5 +149,5 @@ add_custom_target(ALLPIX DEPENDS rootcling_build allpix)
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
-install(TARGETS allpix EUTelConverter DESTINATION bin)
+install(TARGETS allpix DESTINATION bin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,13 @@ else()
         message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
+
+include_directories(/work1/Kilian.Lohmann/ILCSOFT/v01-17-09/lcio/v02-07/include)
+link_directories(/work1/Kilian.Lohmann/ILCSOFT/v01-17-09/lcio/v02-07/lib)
+add_executable(EUTelConverter share/EUTelConverter/RootFileConverter.cc ${sources} ${headers} )
+target_link_libraries(EUTelConverter ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} lcio)
+
+
 #----------------------------------------------------------------------------
 # Copy all scripts to the build directory, i.e. the directory in which we
 # build B5. This is so that we can run the executable directly because it
@@ -125,5 +132,5 @@ add_custom_target(ALLPIX DEPENDS rootcling_build allpix)
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
-install(TARGETS allpix DESTINATION bin)
+install(TARGETS allpix EUTelConverter DESTINATION bin)
 

--- a/include/allpix_dm.h
+++ b/include/allpix_dm.h
@@ -124,6 +124,7 @@ private:
 	TString  fMPXDataSetNumber;
 
 public:
+	FrameStruct(){};
 	FrameStruct(TString);
 	~FrameStruct(){};
 

--- a/include/allpix_dm.h
+++ b/include/allpix_dm.h
@@ -140,6 +140,9 @@ public:
 	void SetnY(int y){fHeight = y;};
 	Int_t GetWidth() {return fWidth;};
 	Int_t GetHeight() {return fHeight;};
+	std::vector<Double_t> const& GetVertex_x() const {return m_primaryVertex_x;};
+	std::vector<Double_t> const& GetVertex_y() const {return m_primaryVertex_y;};
+	std::vector<Double_t> const& GetVertex_z() const {return m_primaryVertex_z;};
 
 	ClassDef(FrameStruct,4)
 };

--- a/include/allpix_dm.h
+++ b/include/allpix_dm.h
@@ -66,6 +66,7 @@ public:
 	void ResetCountersPad();
 	void CleanUpMatrix();
 	void SetFrameAsMCData(){m_isMCData = true;};
+	std::map<int, int> const& GetHitMap() const {return m_frameXC;};
 	Int_t GetEntriesPad(){return m_nEntriesPad;};
 	Int_t GetHitsInPad(){return m_nHitsInPad;};
 	Int_t GetChargeInPad(){return m_nChargeInPad;};
@@ -136,6 +137,8 @@ public:
 	void RewindMetaDataValues();
 	void SetnX(int x){fWidth = x;};
 	void SetnY(int y){fHeight = y;};
+	Int_t GetWidth() {return fWidth;};
+	Int_t GetHeight() {return fHeight;};
 
 	ClassDef(FrameStruct,4)
 };

--- a/models/pixeldetector.xml
+++ b/models/pixeldetector.xml
@@ -105,7 +105,7 @@
 <digitizer>FEI3Standard</digitizer>
 
 <npix_x>80</npix_x>
-<npix_y>360</npix_y>
+<npix_y>336</npix_y>
 <npix_z>0</npix_z>
 
 <pixsize_x units="um">125.</pixsize_x>
@@ -113,7 +113,7 @@
 <pixsize_z units="um">125.</pixsize_z>
 
 <chip_hx units="um">10000</chip_hx>
-<chip_hy units="um">9000</chip_hy>
+<chip_hy units="um">8400</chip_hy>
 <chip_hz units="um">195.0</chip_hz>
 
 
@@ -136,7 +136,7 @@
 <chip_posz units="um">0.</chip_posz>
 
 <sensor_hx units="um">10000</sensor_hx>
-<sensor_hy units="um">9000</sensor_hy>
+<sensor_hy units="um">8400</sensor_hy>
 <sensor_hz units="um">125.0</sensor_hz>
 
 <sensor_gr_excess_htop units="um">100.0</sensor_gr_excess_htop>

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
 	run_header->parameters().setValue  ("EUDRBMode"       , "ZS2");
 	writer->writeRunHeader(run_header.get());
 
-	for (size_t i = 0; i < n_runs; i++) {
+	for (size_t i = 0; i < n_runs+1; i++) {
 
 		LCEventImpl* event = new LCEventImpl();
 		event->setRunNumber(run_number);

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -232,6 +232,7 @@ int main(int argc, char* argv[]) {
 							true_hit_data->setQuality(root_hits[j]->trackId[k]);
 							true_hit_data->setPosition(hit_pos.data());
 							true_hit_data->setEDep(root_hits[j]->edep[k]);
+							true_hit_data->setEDepError(root_hits[j]->edepTotal);
 
 							true_hit_encoder.setCellID(true_hit_data);
 							hit_coll->addElement(true_hit_data);
@@ -273,6 +274,7 @@ int main(int argc, char* argv[]) {
 								true_hit_data->setQuality(hits[k].trackId[l]);
 								true_hit_data->setPosition(hit_pos.data());
 								true_hit_data->setEDep(hits[k].edep[l]);
+								true_hit_data->setEDepError(hits[k].edepTotal);
 
 								true_hit_encoder.setCellID(true_hit_data);
 								hit_coll->addElement(true_hit_data);
@@ -346,7 +348,8 @@ int main(int argc, char* argv[]) {
 								true_hit_data->setType(root_hits[j+n_sensors]->parentId[k]);
 								true_hit_data->setQuality(root_hits[j+n_sensors]->trackId[k]);
 								true_hit_data->setPosition(hit_pos.data());
-								true_hit_data->setEDep(root_hits[j+n_sensors]->edepTotal);
+								true_hit_data->setEDep(root_hits[j+n_sensors]->edep[k]);
+								true_hit_data->setEDepError(root_hits[j+n_sensors]->edepTotal);
 
 								true_hit_encoder.setCellID(true_hit_data);
 								hit_coll->addElement(true_hit_data);
@@ -388,6 +391,7 @@ int main(int argc, char* argv[]) {
 									true_hit_data->setQuality(hits[k].trackId[l]);
 									true_hit_data->setPosition(hit_pos.data());
 									true_hit_data->setEDep(hits[k].edep[l]);
+									true_hit_data->setEDepError(hits[k].edepTotal);
 
 									true_hit_encoder.setCellID(true_hit_data);
 									hit_coll->addElement(true_hit_data);

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -251,6 +251,7 @@ int main(int argc, char* argv[]) {
 							hits_index++;
 						}
 
+						hits[hits_index].edepTotal = root_hits[j]->edepTotal;
 						hits[hits_index].pos.push_back(root_hits[j]->pos[k]);
 						hits[hits_index].edep.push_back(root_hits[j]->edep[k]);
 						hits[hits_index].trackId.push_back(root_hits[j]->trackId[k]);
@@ -368,6 +369,7 @@ int main(int argc, char* argv[]) {
 								hits_index++;
 							}
 
+							hits[hits_index].edepTotal = root_hits[j+n_sensors]->edepTotal;
 							hits[hits_index].pos.push_back(root_hits[j+n_sensors]->pos[k]);
 							hits[hits_index].edep.push_back(root_hits[j+n_sensors]->edep[k]);
 							hits[hits_index].trackId.push_back(root_hits[j+n_sensors]->trackId[k]);

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -237,6 +237,7 @@ int main(int argc, char* argv[]) {
 
 			frame_data->setChargeValues(charge_vec);
 			sensor_frame_coll->addElement(frame_data);
+		}
 
 		event->addCollection(sensor_hit_coll, "true_hits_m26");
 		event->addCollection(sensor_frame_coll, "zsdata_m26");

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -192,10 +192,6 @@ int main(int argc, char* argv[]) {
 		LCCollectionVec* sensor_frame_coll = new LCCollectionVec(LCIO::TRACKERDATA);
 		CellIDEncoder<TrackerDataImpl> frame_encoder_sensor(encoding_string_frame, sensor_frame_coll);
 
-		//Primary vertices collection
-		LCCollectionVec* vertex_coll = new LCCollectionVec(LCIO::TRACKERHIT);
-		CellIDEncoder<TrackerHitImpl> vertex_encoder(encoding_string_hit, vertex_coll);
-
 		//fil telescope collection
 		for (size_t j = 0; j < n_sensors; j++) {
 
@@ -308,33 +304,7 @@ int main(int argc, char* argv[]) {
 
 			frame_data->setChargeValues(charge_vec);
 			sensor_frame_coll->addElement(frame_data);
-
-			//add primary vertex data
-			vertex_encoder.reset();
-			vertex_encoder["sensorID"] = j;
-			vertex_encoder["properties"] = kHitInGlobalCoord + kSimulatedHit;
-
-			std::vector<double> vertex_x = root_frames[j]->GetVertex_x();
-			std::vector<double> vertex_y = root_frames[j]->GetVertex_y();
-			std::vector<double> vertex_z = root_frames[j]->GetVertex_z();
-			std::array<double, 3> vertex_pos;
-			if (vertex_x.size() != root_frames[j]->GetHitMap().size()) std::cout << "vertices vectors have different size than number of hit pixels at event " << i << " and sensor " << j << std::endl;
-			for (size_t k = 0; k < vertex_x.size(); k++) {
-
-				TrackerHitImpl* vertex = new TrackerHitImpl();
-
-				vertex_pos[0] = vertex_x[k];
-				vertex_pos[1] = vertex_y[k];
-				vertex_pos[2] = vertex_z[k];
-
-				vertex->setPosition(vertex_pos.data());
-
-				vertex_encoder.setCellID(vertex);
-				vertex_coll->addElement(vertex);
-			}
 		}
-		//add primary vertex collection to the lcio file
-		event->addCollection(vertex_coll, "primary_vertices");
 
 		//write DUT true hit data collection if there are DUTs present
 		if (n_DUTs > 0) {

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -192,6 +192,10 @@ int main(int argc, char* argv[]) {
 		LCCollectionVec* sensor_frame_coll = new LCCollectionVec(LCIO::TRACKERDATA);
 		CellIDEncoder<TrackerDataImpl> frame_encoder_sensor(encoding_string_frame, sensor_frame_coll);
 
+		//Primary vertices collection
+		LCCollectionVec* vertex_coll = new LCCollectionVec(LCIO::TRACKERHIT);
+		CellIDEncoder<TrackerHitImpl> vertex_encoder(encoding_string_hit, vertex_coll);
+
 		//fil telescope collection
 		for (size_t j = 0; j < n_sensors; j++) {
 
@@ -304,7 +308,33 @@ int main(int argc, char* argv[]) {
 
 			frame_data->setChargeValues(charge_vec);
 			sensor_frame_coll->addElement(frame_data);
+
+			//add primary vertex data
+			vertex_encoder.reset();
+			vertex_encoder["sensorID"] = j;
+			vertex_encoder["properties"] = kHitInGlobalCoord + kSimulatedHit;
+
+			std::vector<double> vertex_x = root_frames[j]->GetVertex_x();
+			std::vector<double> vertex_y = root_frames[j]->GetVertex_y();
+			std::vector<double> vertex_z = root_frames[j]->GetVertex_z();
+			std::array<double, 3> vertex_pos;
+			if (vertex_x.size() != root_frames[j]->GetHitMap().size()) std::cout << "vertices vectors have different size than number of hit pixels at event " << i << " and sensor " << j << std::endl;
+			for (size_t k = 0; k < vertex_x.size(); k++) {
+
+				TrackerHitImpl* vertex = new TrackerHitImpl();
+
+				vertex_pos[0] = vertex_x[k];
+				vertex_pos[1] = vertex_y[k];
+				vertex_pos[2] = vertex_z[k];
+
+				vertex->setPosition(vertex_pos.data());
+
+				vertex_encoder.setCellID(vertex);
+				vertex_coll->addElement(vertex);
+			}
 		}
+		//add primary vertex collection to the lcio file
+		event->addCollection(vertex_coll, "primary_vertices");
 
 		//write DUT true hit data collection if there are DUTs present
 		if (n_DUTs > 0) {

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -204,15 +204,12 @@ int main(int argc, char* argv[]) {
 
 					TrackerHitImpl* true_hit_data = new TrackerHitImpl();
 
-					true_hit_trees[j]->SetBranchAddress("SimpleHits", &root_hit);
-					true_hit_trees[j]->GetEntry(i);
-
 					hit_pos[0] = root_hit->pos[k].X();
 					hit_pos[1] = root_hit->pos[k].Y();
 					hit_pos[2] = root_hit->pos[k].Z();
 
 					true_hit_data->setCellID0(300+j);
-					true_hit_data->setCellID1(sensor_hit_incrs[j]);
+					true_hit_data->setType(sensor_hit_incrs[j]);
 					true_hit_data->setPosition(hit_pos);
 					true_hit_data->setEDep(root_hit->edep[k]);
 
@@ -274,15 +271,12 @@ int main(int argc, char* argv[]) {
 
 						TrackerHitImpl* true_hit_data = new TrackerHitImpl();
 
-						true_hit_trees[j+n_sensors]->SetBranchAddress("SimpleHits", &root_hit);
-						true_hit_trees[j+n_sensors]->GetEntry(i);
-
 						hit_pos[0] = root_hit->pos[k].X();
 						hit_pos[1] = root_hit->pos[k].Y();
 						hit_pos[2] = root_hit->pos[k].Z();
 
 						true_hit_data->setCellID0(DUT_IDs[j]);
-						true_hit_data->setCellID1(DUT_hit_incrs[j]);
+						true_hit_data->setType(DUT_hit_incrs[j]);
 						true_hit_data->setPosition(hit_pos);
 						true_hit_data->setEDep(root_hit->edep[k]);
 
@@ -323,7 +317,7 @@ int main(int argc, char* argv[]) {
 		if (((i+1)%1000 == 0) || (i == 0)) std::cout << "succesfully recorded event " << i+1 << endl;
 	}
 
-	std::cout << "succesfully read in all data\n";
+	std::cout << "succesfully recorder all events\n";
 
 	writer->flush();
 	writer->close();

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -1,0 +1,267 @@
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <cmath>
+#include <vector>
+#include <string>
+
+//#include <TVector3.h>
+#include <TROOT.h>
+//#include <TChain.h>
+#include <TFile.h>
+//#include <TH2.h>
+//#include <TStyle.h>
+//#include <TCanvas.h>
+#include <TTree.h>
+#include <TBranch.h>
+//#include <TObjArray.h>
+//#include <TMath.h>
+
+#include <lcio.h>
+#include <IO/LCWriter.h>
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCEventImpl.h>
+#include <IMPL/LCRunHeaderImpl.h>
+#include <IMPL/LCGenericObjectImpl.h>
+#include <IMPL/TrackerDataImpl.h>
+#include <UTIL/CellIDEncoder.h>
+
+#include "AllPix_Hits_WriteToEntuple.h"
+//#include "AllPix_Hits_WriteToEntuple.cc"
+#include "allpix_dm.h"
+//#include "AllPix_Frames_WriteToEntuple.h"
+//#include "AllPix_Frames_WriteToEntuple.cc"
+
+using namespace lcio;
+
+void print_info();
+
+int main(int argc, char* argv[]) {
+
+	std::string output_file, file_path;
+	int n_sensors, n_DUTs;
+	std::vector<int> DUT_IDs;
+
+	if (argc < 4) print_info(); //if not enough arguments are given, print user info
+	else {
+
+		sscanf(argv[1], "%d", &n_sensors);
+		sscanf(argv[2], "%d", &n_DUTs);
+		sscanf(argv[3], "%s", &output_file);
+
+		if ((argc > 4) && (n_DUTs <= 0)) sscanf(argv[4], "%s", &file_path);
+		else {
+
+			DUT_IDs = std::vector<int>(n_DUTs);
+
+			for (int i = 0; i < n_DUTs; i++) {
+
+				sscanf(argv[4+i], "%d", &DUT_IDs[i]);
+			}
+
+			if (argc > 4+n_DUTs) sscanf(argv[4+n_DUTs], "%s", &file_path);
+		}
+	}
+
+	TFile** true_hit_files = new TFile*[n_sensors+n_DUTs];
+	TTree** true_hit_trees = new TTree*[n_sensors+n_DUTs];
+	TFile** frame_files = new TFile*[n_sensors+n_DUTs];
+	TTree** frame_trees = new TTree*[n_sensors+n_DUTs];
+
+	std::ostringstream oss;
+
+	for (int i = 0; i < n_sensors; i++) {
+
+		oss.str(std::string());//resets oss to an empty string
+		oss << file_path << "Hits_BoxSD_" << i+300 << "_HitsCollection.root";
+
+		true_hit_files[i] = new TFile(oss.str().c_str());
+		true_hit_trees[i] = (TTree*) true_hit_files[i]->Get("AllPixHits");
+
+		oss.str(std::string());
+		oss << file_path << "MPXNtuple_allPix_det_" << i+300 << ".root";
+
+		frame_files[i] = new TFile(oss.str().c_str());
+		frame_trees[i] = (TTree*) frame_files[i]->Get("MPXTree");
+	}
+
+	for (int i = 0; i < n_DUTs; i++) {
+
+		oss.str(std::string());
+		oss << file_path << "Hits_BoxSD_" << DUT_IDs[i] << "_HitsCollection.root";
+
+		true_hit_files[i+n_sensors] = new TFile(oss.str().c_str());
+		true_hit_trees[i+n_sensors] = (TTree*)true_hit_files[i+n_sensors]->Get("AllPixHits");
+
+		oss.str(std::string());
+		oss << file_path << "MPXNtuple_allPix_det_" << DUT_IDs[i] << ".root";
+
+		frame_files[i+n_sensors] = new TFile(oss.str().c_str());
+		frame_trees[i+n_sensors] = (TTree*) frame_files[i+n_sensors]->Get("MPXTree");
+	}
+
+	int n_entries = true_hit_trees[0]->GetEntries();
+
+	SimpleHits root_hit;
+	true_hit_trees[0]->SetBranchAddress("SimpleHits", &root_hit);		
+	true_hit_trees[0]->GetEntry(0);
+	int run_number = root_hit.run;
+
+	std::string detector_name = "EUTelescope";
+
+	LCWriter* writer = LCFactory::getInstance()->createLCWriter();
+	writer->open(output_file);
+
+	LCRunHeaderImpl* run_header = new LCRunHeaderImpl; 
+	run_header->setRunNumber(run_number);
+	run_header->setDetectorName(detector_name);
+	run_header->parameters().setValue  ("GeoID"           , 0);
+	run_header->parameters().setValues ("MaxX"            , std::vector<int>(6,1151));
+	run_header->parameters().setValues ("MaxY"            , std::vector<int>(6,575));
+	run_header->parameters().setValues ("MinX"            , std::vector<int>(6,0));
+	run_header->parameters().setValues ("MinY"            , std::vector<int>(6,0));
+	run_header->parameters().setValue  ("NoOfDetector"    , 6);
+	run_header->parameters().setValues ("AppliedProcessor", std::vector<std::string>(1,""));
+	run_header->parameters().setValue  ("DAQHWName"       , "EUDRB");
+	run_header->parameters().setValue  ("DAQSWName"       , "EUDAQ");
+	run_header->parameters().setValue  ("DataType"        , "SimData");
+	run_header->parameters().setValue  ("DateTime"        , "24.12.2000  23:59:59.000000000");
+	run_header->parameters().setValue  ("EUDRBDet"        , "MIMOSA26");
+	run_header->parameters().setValue  ("EUDRBMode"       , "ZS2");
+   	writer->writeRunHeader(run_header);
+	delete run_header;
+
+	for (int i = 0; i < n_entries; i++) {
+
+		LCEventImpl* event = new LCEventImpl();
+		event->setRunNumber(run_number);
+		event->setEventNumber(i);
+		event->setDetectorName(detector_name);
+		event->setTimeStamp( (int) time(NULL)*1000000000.0);
+		event->parameters().setValue("EventType", 2);
+
+		if (i == 0) {
+
+			LCCollectionVec* eudrb_setup = new LCCollectionVec(LCIO::LCGENERICOBJECT);
+
+			//collection parameters
+			eudrb_setup->parameters().setValue("DataDescription", "type:i,mode:i,spare1:i,spare2:i,spare3:i");
+			eudrb_setup->parameters().setValue("TypeName", "Setup Description");
+
+			//create one setup object per Telescope plane
+			for (int n = 0; n < n_sensors; n++) {
+
+				LCGenericObjectImpl* setup_obj = new LCGenericObjectImpl(5,0,0);
+				setup_obj->setIntVal(0, 102);
+				setup_obj->setIntVal(1, 101);
+				eudrb_setup->addElement(setup_obj);
+			}
+
+			event->addCollection(eudrb_setup, "eudrbSetup");
+		}
+
+		//ID encoder info
+		std::string encoding_string = "sensorID:7,sparsePixelType:5";
+
+		//Telescope data collection
+		LCCollectionVec* tracker_data_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+		CellIDEncoder<TrackerDataImpl> id_encoder_telescope(encoding_string, tracker_data_coll);// = new CellIDEncoder<TrackerDataImpl>(encoding_string, tracker_data_coll);
+
+		//fil telescope collection
+		for (int j = 0; j < n_sensors; j++) {
+
+			//to-do: initiate the planeData and idEncoder_Telesope
+
+			true_hit_trees[j]->SetBranchAddress("SimpleHits", &root_hit);
+			true_hit_trees[j]->GetEntry(i);
+
+			TrackerDataImpl* plane_data = new TrackerDataImpl();
+
+			id_encoder_telescope.reset();
+			id_encoder_telescope["sensorID"] = j + 300;
+			id_encoder_telescope["sparsePixelType"] = 2;
+			id_encoder_telescope.setCellID(plane_data);
+
+			//loop over hits
+			std::vector<float> charge_vec;
+			for (int k = 0; k < root_hit.pos.size(); k++) {
+
+				charge_vec.push_back(root_hit.pos[k].X());
+				charge_vec.push_back(root_hit.pos[k].Y());
+				charge_vec.push_back(root_hit.edep[k]);
+				charge_vec.push_back(0);
+			}
+
+			plane_data->setChargeValues(charge_vec);
+			tracker_data_coll->addElement(plane_data);
+
+			charge_vec.clear();
+		}
+
+		event->addCollection(tracker_data_coll, "true_hits_m26");
+
+		//write DUT true hit data collection if there are DUTs present
+		if (n_DUTs > 0) {
+
+			LCCollectionVec* DUT_data_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+			CellIDEncoder<TrackerDataImpl> id_encoder_DUT(encoding_string, DUT_data_coll);
+
+			for (int j = 0; j < n_DUTs; j++) {
+
+				true_hit_trees[j+n_sensors]->SetBranchAddress("SimpleHits", &root_hit);
+				true_hit_trees[j+n_sensors]->GetEntry(i);
+
+				TrackerDataImpl* plane_data = new TrackerDataImpl();
+
+				id_encoder_DUT.reset();
+				id_encoder_DUT["sensorID"] = DUT_IDs[j];
+				id_encoder_DUT["sparsePixelType"] = 2;
+				id_encoder_DUT.setCellID(plane_data);
+
+				std::vector<float> charge_vec;
+				for (int k = 0; k < root_hit.pos.size(); k++) {
+
+					charge_vec.push_back(root_hit.pos[k].X());
+					charge_vec.push_back(root_hit.pos[k].Y());
+					charge_vec.push_back(root_hit.edep[k]);
+					charge_vec.push_back(0);
+				}
+
+				plane_data->setChargeValues(charge_vec);
+				DUT_data_coll->addElement(plane_data);
+
+				charge_vec.clear();
+			}
+
+			event->addCollection(DUT_data_coll, "true_hits_DUT");
+		}
+
+
+		writer->writeEvent(event);
+
+		delete event;
+	}
+
+	writer->flush();
+	writer->close();
+
+	for (int i = 0; i < n_sensors; i++) {
+
+		true_hit_files[i]->Close();
+		delete true_hit_trees[i];
+		delete true_hit_files[i];
+	}
+
+	delete [] true_hit_trees;
+	delete [] true_hit_files;
+
+	return 0;
+}
+
+void print_info() {
+
+	std::cout << "Converts allpix generated root files into LCIO format" << std::endl;
+	std::cout << "Usage: compile and run with the arguments in the following order:" << std::endl;
+	std::cout << "<number of sensors> <number of DUTs> <output file name> <list of DUT sensor IDs> <path to folder containing input root files>" << std::endl;
+	std::cout << "if no DUTs are present, inputing 0 for the number of DUTs means that the list of DUTs is no longer required. The fourth argument will be interpreted as the path to folder containing input root files." << std::endl;
+}

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -4,18 +4,12 @@
 #include <cmath>
 #include <vector>
 #include <string>
+#include <map>
 
-//#include <TVector3.h>
 #include <TROOT.h>
-//#include <TChain.h>
 #include <TFile.h>
-//#include <TH2.h>
-//#include <TStyle.h>
-//#include <TCanvas.h>
 #include <TTree.h>
 #include <TBranch.h>
-//#include <TObjArray.h>
-//#include <TMath.h>
 
 #include <lcio.h>
 #include <IO/LCWriter.h>
@@ -27,10 +21,8 @@
 #include <UTIL/CellIDEncoder.h>
 
 #include "AllPix_Hits_WriteToEntuple.h"
-//#include "AllPix_Hits_WriteToEntuple.cc"
+#include "AllPix_Frames_WriteToEntuple.h"
 #include "allpix_dm.h"
-//#include "AllPix_Frames_WriteToEntuple.h"
-//#include "AllPix_Frames_WriteToEntuple.cc"
 
 using namespace lcio;
 
@@ -42,14 +34,18 @@ int main(int argc, char* argv[]) {
 	int n_sensors, n_DUTs;
 	std::vector<int> DUT_IDs;
 
-	if (argc < 4) print_info(); //if not enough arguments are given, print user info
+	if (argc < 4) {
+
+		print_info();//if not enough arguments are given, print user info
+		return 0;
+	}
 	else {
 
 		sscanf(argv[1], "%d", &n_sensors);
 		sscanf(argv[2], "%d", &n_DUTs);
-		sscanf(argv[3], "%s", &output_file);
+		output_file = argv[3];
 
-		if ((argc > 4) && (n_DUTs <= 0)) sscanf(argv[4], "%s", &file_path);
+		if ((argc > 4) && (n_DUTs <= 0)) file_path = argv[4];
 		else {
 
 			DUT_IDs = std::vector<int>(n_DUTs);
@@ -59,9 +55,11 @@ int main(int argc, char* argv[]) {
 				sscanf(argv[4+i], "%d", &DUT_IDs[i]);
 			}
 
-			if (argc > 4+n_DUTs) sscanf(argv[4+n_DUTs], "%s", &file_path);
+			if (argc > 4+n_DUTs) file_path = argv[4+n_DUTs];
 		}
 	}
+
+	cout << "succesfully initiated variables:\noutput_file = " << output_file << "\nfile_path = " << file_path << "\nn_sensors = " << n_sensors << "\nn_DUTs = " << n_DUTs << endl;
 
 	TFile** true_hit_files = new TFile*[n_sensors+n_DUTs];
 	TTree** true_hit_trees = new TTree*[n_sensors+n_DUTs];
@@ -78,11 +76,15 @@ int main(int argc, char* argv[]) {
 		true_hit_files[i] = new TFile(oss.str().c_str());
 		true_hit_trees[i] = (TTree*) true_hit_files[i]->Get("AllPixHits");
 
+		std::cout << "succesfully opened file: " << oss.str() << std::endl;
+
 		oss.str(std::string());
 		oss << file_path << "MPXNtuple_allPix_det_" << i+300 << ".root";
 
 		frame_files[i] = new TFile(oss.str().c_str());
 		frame_trees[i] = (TTree*) frame_files[i]->Get("MPXTree");
+
+		std::cout << "succesfully opened file: " << oss.str() << std::endl;
 	}
 
 	for (int i = 0; i < n_DUTs; i++) {
@@ -92,25 +94,34 @@ int main(int argc, char* argv[]) {
 
 		true_hit_files[i+n_sensors] = new TFile(oss.str().c_str());
 		true_hit_trees[i+n_sensors] = (TTree*)true_hit_files[i+n_sensors]->Get("AllPixHits");
+		std::cout << "succesfully opened file: " << oss.str() << std::endl;
 
 		oss.str(std::string());
 		oss << file_path << "MPXNtuple_allPix_det_" << DUT_IDs[i] << ".root";
 
 		frame_files[i+n_sensors] = new TFile(oss.str().c_str());
 		frame_trees[i+n_sensors] = (TTree*) frame_files[i+n_sensors]->Get("MPXTree");
+		std::cout << "succesfully opened file: " << oss.str() << std::endl;
 	}
 
 	int n_entries = true_hit_trees[0]->GetEntries();
 
-	SimpleHits root_hit;
+	cout << "succesfully got number of entries: " << n_entries << endl;
+
+	FrameStruct* root_frame = NULL;
+	SimpleHits* root_hit = NULL;
 	true_hit_trees[0]->SetBranchAddress("SimpleHits", &root_hit);		
 	true_hit_trees[0]->GetEntry(0);
-	int run_number = root_hit.run;
+	int run_number = root_hit->run;
+
+	cout << "succesfully got run number: " << run_number << endl;
 
 	std::string detector_name = "EUTelescope";
 
 	LCWriter* writer = LCFactory::getInstance()->createLCWriter();
-	writer->open(output_file);
+	writer->open(output_file, LCIO::WRITE_NEW);
+
+	cout << "succesfully opened instance of LCWriter\n";
 
 	LCRunHeaderImpl* run_header = new LCRunHeaderImpl; 
 	run_header->setRunNumber(run_number);
@@ -164,96 +175,157 @@ int main(int argc, char* argv[]) {
 		std::string encoding_string = "sensorID:7,sparsePixelType:5";
 
 		//Telescope data collection
-		LCCollectionVec* tracker_data_coll = new LCCollectionVec(LCIO::TRACKERDATA);
-		CellIDEncoder<TrackerDataImpl> id_encoder_telescope(encoding_string, tracker_data_coll);// = new CellIDEncoder<TrackerDataImpl>(encoding_string, tracker_data_coll);
+		LCCollectionVec* sensor_hit_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+		LCCollectionVec* sensor_frame_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+		CellIDEncoder<TrackerDataImpl> id_encoder_telescope(encoding_string, sensor_hit_coll);
 
 		//fil telescope collection
 		for (int j = 0; j < n_sensors; j++) {
 
-			//to-do: initiate the planeData and idEncoder_Telesope
+			TrackerDataImpl* true_hit_data = new TrackerDataImpl();
+			TrackerDataImpl* frame_data = new TrackerDataImpl();
 
 			true_hit_trees[j]->SetBranchAddress("SimpleHits", &root_hit);
 			true_hit_trees[j]->GetEntry(i);
+			frame_trees[j]->SetBranchAddress("FramesData", &root_frame);
+			frame_trees[j]->GetEntry(i);
 
-			TrackerDataImpl* plane_data = new TrackerDataImpl();
 
 			id_encoder_telescope.reset();
-			id_encoder_telescope["sensorID"] = j + 300;
+			id_encoder_telescope["sensorID"] = j;
 			id_encoder_telescope["sparsePixelType"] = 2;
-			id_encoder_telescope.setCellID(plane_data);
+			id_encoder_telescope.setCellID(true_hit_data);
+			id_encoder_telescope.setCellID(frame_data);
 
-			//loop over hits
+			//loop over true hits
 			std::vector<float> charge_vec;
-			for (int k = 0; k < root_hit.pos.size(); k++) {
+			for (unsigned int k = 0; k < root_hit->pos.size(); k++) {
 
-				charge_vec.push_back(root_hit.pos[k].X());
-				charge_vec.push_back(root_hit.pos[k].Y());
-				charge_vec.push_back(root_hit.edep[k]);
+				charge_vec.push_back(root_hit->pos[k].X());
+				charge_vec.push_back(root_hit->pos[k].Y());
+				charge_vec.push_back(root_hit->edep[k]);
 				charge_vec.push_back(0);
 			}
 
-			plane_data->setChargeValues(charge_vec);
-			tracker_data_coll->addElement(plane_data);
+			true_hit_data->setChargeValues(charge_vec);
+			sensor_hit_coll->addElement(true_hit_data);
+			charge_vec.clear();
 
+			//loop over hits from frame
+			for (auto it = root_frame->GetHitMap().begin(); it != root_frame->GetHitMap().end(); ++it) {
+
+				//the key contains position of hit in the format key = y*width + x
+				float x = (it->first)%root_frame->GetWidth();
+				float y = (it->first)/root_frame->GetWidth();
+				float TOT = it->second;
+
+				charge_vec.push_back(x);
+				charge_vec.push_back(y);
+				charge_vec.push_back(TOT);
+				charge_vec.push_back(0);
+			}
+
+			frame_data->setChargeValues(charge_vec);
+			sensor_frame_coll->addElement(frame_data);
 			charge_vec.clear();
 		}
 
-		event->addCollection(tracker_data_coll, "true_hits_m26");
+		event->addCollection(sensor_hit_coll, "true_hits_m26");
+		event->addCollection(sensor_frame_coll, "zsdata_m26");
 
 		//write DUT true hit data collection if there are DUTs present
 		if (n_DUTs > 0) {
 
-			LCCollectionVec* DUT_data_coll = new LCCollectionVec(LCIO::TRACKERDATA);
-			CellIDEncoder<TrackerDataImpl> id_encoder_DUT(encoding_string, DUT_data_coll);
+			LCCollectionVec* DUT_hit_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+			LCCollectionVec* DUT_frame_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+			CellIDEncoder<TrackerDataImpl> id_encoder_DUT(encoding_string, DUT_hit_coll);
 
 			for (int j = 0; j < n_DUTs; j++) {
 
+				TrackerDataImpl* true_hit_data = new TrackerDataImpl();
+				TrackerDataImpl* frame_data = new TrackerDataImpl();
+
 				true_hit_trees[j+n_sensors]->SetBranchAddress("SimpleHits", &root_hit);
 				true_hit_trees[j+n_sensors]->GetEntry(i);
-
-				TrackerDataImpl* plane_data = new TrackerDataImpl();
+				frame_trees[j+n_sensors]->SetBranchAddress("FramesData", &root_frame);
+				frame_trees[j+n_sensors]->GetEntry(i);
 
 				id_encoder_DUT.reset();
-				id_encoder_DUT["sensorID"] = DUT_IDs[j];
+				id_encoder_DUT["sensorID"] = j + 6;
 				id_encoder_DUT["sparsePixelType"] = 2;
-				id_encoder_DUT.setCellID(plane_data);
+				id_encoder_DUT.setCellID(true_hit_data);
+				id_encoder_DUT.setCellID(frame_data);
 
 				std::vector<float> charge_vec;
-				for (int k = 0; k < root_hit.pos.size(); k++) {
+				for (unsigned int k = 0; k < root_hit->pos.size(); k++) {
 
-					charge_vec.push_back(root_hit.pos[k].X());
-					charge_vec.push_back(root_hit.pos[k].Y());
-					charge_vec.push_back(root_hit.edep[k]);
+					charge_vec.push_back(root_hit->pos[k].X());
+					charge_vec.push_back(root_hit->pos[k].Y());
+					charge_vec.push_back(root_hit->edep[k]);
 					charge_vec.push_back(0);
 				}
 
-				plane_data->setChargeValues(charge_vec);
-				DUT_data_coll->addElement(plane_data);
+				true_hit_data->setChargeValues(charge_vec);
+				DUT_hit_coll->addElement(true_hit_data);
+				charge_vec.clear();
 
+				for (auto it = root_frame->GetHitMap().begin(); it != root_frame->GetHitMap().end(); ++it) {
+
+					float x = (it->first)%root_frame->GetWidth();
+					float y = (it->first)/root_frame->GetWidth();
+					float TOT = it->second;
+
+					charge_vec.push_back(x);
+					charge_vec.push_back(y);
+					charge_vec.push_back(TOT);
+					charge_vec.push_back(0);
+				}
+
+				frame_data->setChargeValues(charge_vec);
+				DUT_frame_coll->addElement(frame_data);
 				charge_vec.clear();
 			}
 
-			event->addCollection(DUT_data_coll, "true_hits_DUT");
+			event->addCollection(DUT_hit_coll, "true_hits_DUT");
+			event->addCollection(DUT_frame_coll, "zsdata_DUT");
 		}
 
 
 		writer->writeEvent(event);
-
 		delete event;
+
+		if (((i+1)%1000 == 0) || (i == 0)) cout << "succesfully recorded event " << i+1 << endl;
 	}
+
+	cout << "succesfully read in all data\n";
 
 	writer->flush();
 	writer->close();
 
-	for (int i = 0; i < n_sensors; i++) {
+	cout << "succesfully closed the writer\n";
+
+	for (int i = 0; i < n_sensors+n_DUTs; i++) {
 
 		true_hit_files[i]->Close();
-		delete true_hit_trees[i];
+		frame_files[i]->Close();
+
+		cout << "succesfully closed files " << i << endl;
+
 		delete true_hit_files[i];
+		delete frame_files[i];
+
+		cout << "succesfully deleted trees and files " << i << endl;
 	}
 
 	delete [] true_hit_trees;
 	delete [] true_hit_files;
+
+	cout << "succesfully deleted trees and files arrays\n";
+
+	delete root_hit;
+	delete root_frame;
+
+	cout << "succesfully deleted root_hit and root_frame\n";
 
 	return 0;
 }
@@ -264,4 +336,6 @@ void print_info() {
 	std::cout << "Usage: compile and run with the arguments in the following order:" << std::endl;
 	std::cout << "<number of sensors> <number of DUTs> <output file name> <list of DUT sensor IDs> <path to folder containing input root files>" << std::endl;
 	std::cout << "if no DUTs are present, inputing 0 for the number of DUTs means that the list of DUTs is no longer required. The fourth argument will be interpreted as the path to folder containing input root files." << std::endl;
+
+	return;
 }

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -215,31 +215,72 @@ int main(int argc, char* argv[]) {
 			while (true_hit_trees[j]->GetEntry(hit_incrs[j]) and root_hits[j]->run == (int)i) {
 
 				auto hit_pos = std::array<double,3>();
-				//double z_pos = (root_hits[j]->pos.front().Z() + root_hits[j]->pos.back().Z() - 1e-3)/2.0;
-				for (size_t k = 0; k < root_hits[j]->pos.size(); k++) {
+				if (root_hits[j]->trackId.back() == 1) {//only a single track in this event
 
-					//if (abs(root_hits[j]->pos[k].Z()-z_pos) < 7e-4) {
-					if (k == root_hits[j]->pos.size()/2 - 1) {
+					for (size_t k = 0; k < root_hits[j]->pos.size(); k++) {
 
-						TrackerHitImpl* true_hit_data = new TrackerHitImpl();
+						if (k == root_hits[j]->pos.size()/2 - 1) {
 
-						hit_pos[0] = root_hits[j]->pos[k].X();
-						hit_pos[1] = root_hits[j]->pos[k].Y();
-						hit_pos[2] = root_hits[j]->pos[k].Z();
+							TrackerHitImpl* true_hit_data = new TrackerHitImpl();
 
-						true_hit_data->setType(root_hits[j]->event);
-						true_hit_data->setQuality(root_hits[j]->trackId[k]);
-						true_hit_data->setPosition(hit_pos.data());
-						true_hit_data->setEDep(root_hits[j]->edep[k]);
-						//true_hit_data->setEDepError(z_pos);
-						//true_hit_data->setTime(root_hits[j]->parentId[k]);
+							hit_pos[0] = root_hits[j]->pos[k].X();
+							hit_pos[1] = root_hits[j]->pos[k].Y();
+							hit_pos[2] = root_hits[j]->pos[k].Z();
 
-						true_hit_encoder.setCellID(true_hit_data);
-						hit_coll->addElement(true_hit_data);
+							true_hit_data->setTime(root_hits[j]->event);
+							true_hit_data->setType(root_hits[j]->parentId[k]);
+							true_hit_data->setQuality(root_hits[j]->trackId[k]);
+							true_hit_data->setPosition(hit_pos.data());
+							true_hit_data->setEDep(root_hits[j]->edep[k]);
 
+							true_hit_encoder.setCellID(true_hit_data);
+							hit_coll->addElement(true_hit_data);
+						}
 					}
 				}
+				else {//more than one track in this event
 
+					vector<SimpleHits> hits;
+					int hits_index = -1;
+					for (size_t k = 0; k < root_hits[j]->pos.size(); k++) {
+
+						if ((k == 0) || (root_hits[j]->trackId[k] != root_hits[j]->trackId[k-1]) || (root_hits[j]->interactions[k-1] == "Transportation")) {
+
+							hits.push_back(SimpleHits());
+							hits_index++;
+						}
+
+						hits[hits_index].pos.push_back(root_hits[j]->pos[k]);
+						hits[hits_index].edep.push_back(root_hits[j]->edep[k]);
+						hits[hits_index].trackId.push_back(root_hits[j]->trackId[k]);
+						hits[hits_index].parentId.push_back(root_hits[j]->parentId[k]);
+					}
+
+					for (size_t k = 0; k < hits.size(); k++) {
+
+						for (size_t l = 0; l < hits[k].pos.size(); l++) {
+
+							if ((l == hits[k].pos.size()/2 - 1) || (hits[k].pos.size() == 1)) {
+
+								TrackerHitImpl* true_hit_data = new TrackerHitImpl();
+
+								hit_pos[0] = hits[k].pos[l].X();
+								hit_pos[1] = hits[k].pos[l].Y();
+								hit_pos[2] = hits[k].pos[l].Z();
+
+								true_hit_data->setTime(root_hits[j]->event);
+								true_hit_data->setType(hits[k].parentId[l]);
+								true_hit_data->setQuality(hits[k].trackId[l]);
+								true_hit_data->setPosition(hit_pos.data());
+								true_hit_data->setEDep(hits[k].edep[l]);
+
+								true_hit_encoder.setCellID(true_hit_data);
+								hit_coll->addElement(true_hit_data);
+							}
+						}
+					}
+				}
+						
 				hit_incrs[j]++;
 			}
 
@@ -289,23 +330,69 @@ int main(int argc, char* argv[]) {
 				while (true_hit_trees[j+n_sensors]->GetEntry(hit_incrs[j+n_sensors]) and root_hits[j+n_sensors]->run == (int)i) {
 
 					auto hit_pos = std::array<double,3>();
-					for (size_t k = 0; k < root_hits[j+n_sensors]->pos.size(); k++) {
+					if (root_hits[j+n_sensors]->trackId.back() == 1) {
 
-						if (k == root_hits[j+n_sensors]->pos.size()/2 - 1) {
+						for (size_t k = 0; k < root_hits[j+n_sensors]->pos.size(); k++) {
 
-							TrackerHitImpl* true_hit_data = new TrackerHitImpl();
+							if (k == root_hits[j+n_sensors]->pos.size()/2 - 1) {
 
-							hit_pos[0] = root_hits[j+n_sensors]->pos[k].X();
-							hit_pos[1] = root_hits[j+n_sensors]->pos[k].Y();
-							hit_pos[2] = root_hits[j+n_sensors]->pos[k].Z();
+								TrackerHitImpl* true_hit_data = new TrackerHitImpl();
 
-							true_hit_data->setType(root_hits[j]->event);
-							true_hit_data->setQuality(root_hits[j]->trackId[k]);
-							true_hit_data->setPosition(hit_pos.data());
-							true_hit_data->setEDep(root_hits[j+n_sensors]->edepTotal);
+								hit_pos[0] = root_hits[j+n_sensors]->pos[k].X();
+								hit_pos[1] = root_hits[j+n_sensors]->pos[k].Y();
+								hit_pos[2] = root_hits[j+n_sensors]->pos[k].Z();
 
-							true_hit_encoder.setCellID(true_hit_data);
-							hit_coll->addElement(true_hit_data);
+								true_hit_data->setTime(root_hits[j+n_sensors]->event);
+								true_hit_data->setType(root_hits[j+n_sensors]->parentId[k]);
+								true_hit_data->setQuality(root_hits[j+n_sensors]->trackId[k]);
+								true_hit_data->setPosition(hit_pos.data());
+								true_hit_data->setEDep(root_hits[j+n_sensors]->edepTotal);
+
+								true_hit_encoder.setCellID(true_hit_data);
+								hit_coll->addElement(true_hit_data);
+							}
+						}
+					}
+					else {
+
+						vector<SimpleHits> hits;
+						int hits_index = -1;
+						for (size_t k = 0; k < root_hits[j+n_sensors]->pos.size(); k++) {
+
+							if ((k == 0) || (root_hits[j+n_sensors]->trackId[k] != root_hits[j+n_sensors]->trackId[k-1]) || (root_hits[j+n_sensors]->interactions[k-1] == "Transportation")) {
+
+								hits.push_back(SimpleHits());
+								hits_index++;
+							}
+
+							hits[hits_index].pos.push_back(root_hits[j+n_sensors]->pos[k]);
+							hits[hits_index].edep.push_back(root_hits[j+n_sensors]->edep[k]);
+							hits[hits_index].trackId.push_back(root_hits[j+n_sensors]->trackId[k]);
+							hits[hits_index].parentId.push_back(root_hits[j+n_sensors]->parentId[k]);
+						}
+
+						for (size_t k = 0; k < hits.size(); k++) {
+
+							for (size_t l = 0; l < hits[k].pos.size(); l++) {
+
+								if ((l == hits[k].pos.size()/2 - 1) || (hits[k].pos.size() == 1)) {
+
+									TrackerHitImpl* true_hit_data = new TrackerHitImpl();
+
+									hit_pos[0] = hits[k].pos[l].X();
+									hit_pos[1] = hits[k].pos[l].Y();
+									hit_pos[2] = hits[k].pos[l].Z();
+
+									true_hit_data->setTime(root_hits[j+n_sensors]->event);
+									true_hit_data->setType(hits[k].parentId[l]);
+									true_hit_data->setQuality(hits[k].trackId[l]);
+									true_hit_data->setPosition(hit_pos.data());
+									true_hit_data->setEDep(hits[k].edep[l]);
+
+									true_hit_encoder.setCellID(true_hit_data);
+									hit_coll->addElement(true_hit_data);
+								}
+							}
 						}
 					}
 

--- a/share/EUTelConverter/RootFileConverter.cc
+++ b/share/EUTelConverter/RootFileConverter.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <vector>
 #include <string>
+#include <array>
 #include <map>
 
 #include <TROOT.h>
@@ -27,6 +28,31 @@
 
 using namespace lcio;
 
+/*struct TrueHit {
+
+	double edep_total;
+	double sensor_ID;
+
+	std::vector<double*> pos;
+	std::vector<int> pdgId;
+	std::vector<float> edep;
+
+	~TrueHit() {
+
+		for (unsigned int i = 0; i < pos.size(); i++) delete [] pos[i];
+	}
+};
+
+struct Event {
+
+	std::vector<TrueHit*> hits;
+
+	~Event() {
+
+		for (unsigned int i = 0; i < hits.size(); i++) delete hits[i];
+	}
+};*/
+
 void print_info();
 
 int main(int argc, char* argv[]) {
@@ -35,7 +61,7 @@ int main(int argc, char* argv[]) {
 	int n_sensors, n_DUTs;
 	std::vector<int> DUT_IDs;
 
-	if (argc < 3) {
+	if (argc < 4) {
 
 		print_info();//if not enough arguments are given, print user info
 		return 0;
@@ -51,7 +77,7 @@ int main(int argc, char* argv[]) {
 			for (int i = 0; i < 4-argc; i++) {
 
 				int temp = 0;
-				sscanf(argv[3+i], "%d", &temp);
+				sscanf(argv[4+i], "%d", &temp);
 				DUT_IDs.push_back(temp);
 			}
 		}
@@ -104,19 +130,29 @@ int main(int argc, char* argv[]) {
 		frame_trees[i+n_sensors] = (TTree*) frame_files[i+n_sensors]->Get("MPXTree");
 	}
 
+	FrameStruct** root_frames = new FrameStruct*[n_sensors+n_DUTs];
+	SimpleHits** root_hits = new SimpleHits*[n_sensors+n_DUTs];
+	for (int i = 0; i < n_sensors+n_DUTs; i++) {
+
+		root_frames[i] = NULL;
+		root_hits[i] = NULL;
+
+		frame_trees[i]->SetBranchAddress("FramesData", &root_frames[i]);
+		true_hit_trees[i]->SetBranchAddress("SimpleHits", &root_hits[i]);
+
+	}
+
 	int n_entries = true_hit_trees[0]->GetEntries();
-
-	FrameStruct* root_frame = NULL;
-	SimpleHits* root_hit = NULL;
-	true_hit_trees[0]->SetBranchAddress("SimpleHits", &root_hit);		
 	true_hit_trees[0]->GetEntry(n_entries-1);
-	int n_runs = root_hit->run;
-	int run_number = 0;
-	std::vector<int> sensor_hit_incrs(n_sensors);
-	for (int i = 0; i < n_sensors; i++) sensor_hit_incrs[i] = 0;
-	std::vector<int> DUT_hit_incrs(n_DUTs);
-	for (int i = 0; i < n_DUTs; i++) DUT_hit_incrs[i] = 0;
+	int n_runs = root_hits[0]->run;
 
+	/*Event** hit_events = new Event*[n_runs];
+	for (int i = 0; i < n_runs; i++) hit_events[i] = new Event();*/
+
+	std::vector<int> hit_incrs(n_sensors+n_DUTs);
+	for (int i = 0; i < n_sensors+n_DUTs; i++) hit_incrs[i] = 0;
+
+	int run_number = 0;
 	std::string detector_name = "EUTelescope";
 
 	LCWriter* writer = LCFactory::getInstance()->createLCWriter();
@@ -139,7 +175,7 @@ int main(int argc, char* argv[]) {
 	run_header->parameters().setValue  ("DateTime"        , "24.12.2000  23:59:59.000000000");
 	run_header->parameters().setValue  ("EUDRBDet"        , "MIMOSA26");
 	run_header->parameters().setValue  ("EUDRBMode"       , "ZS2");
-   	writer->writeRunHeader(run_header);
+	writer->writeRunHeader(run_header);
 	delete run_header;
 
 	for (int i = 0; i < n_runs; i++) {
@@ -177,6 +213,7 @@ int main(int argc, char* argv[]) {
 		//Telescope data collection
 		LCCollectionVec* sensor_hit_coll = new LCCollectionVec(LCIO::TRACKERHIT);
 		LCCollectionVec* sensor_frame_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+		//LCCollectionVec* sensor_vertex_coll = new LCCollectionVec(LCIO::TRACKERHIT);
 		CellIDEncoder<TrackerDataImpl> frame_encoder_sensor(encoding_string, sensor_frame_coll);
 
 		//fil telescope collection
@@ -184,9 +221,7 @@ int main(int argc, char* argv[]) {
 
 			TrackerDataImpl* frame_data = new TrackerDataImpl();
 
-			frame_trees[j]->SetBranchAddress("FramesData", &root_frame);
 			frame_trees[j]->GetEntry(i);
-			true_hit_trees[j]->SetBranchAddress("SimpleHits", &root_hit);
 
 			frame_encoder_sensor.reset();
 			frame_encoder_sensor["sensorID"] = j;
@@ -197,37 +232,51 @@ int main(int argc, char* argv[]) {
 			//there are multiple entries with the same run (aka event) number,
 			//hence must loop over all the entries with the same run number as
 			//the first for loop (looping over run numbers)
-			while (true_hit_trees[j]->GetEntry(sensor_hit_incrs[j]) and root_hit->run == i) {
+			while (true_hit_trees[j]->GetEntry(hit_incrs[j]) and root_hits[j]->run == i) {
+
+				/*hit_events[i]->hits.push_back(new TrueHit());
+				hit_events[i]->hits.back()->sensor_ID = 300+j;
+				hit_events[i]->hits.back()->edep_total = root_hits[j]->edepTotal;
+				hit_events[i]->hits.back()->pdgId = root_hits[j]->pdgId;
+				hit_events[i]->hits.back()->edep = root_hits[j]->edep;*/
 
 				double* hit_pos = new double[3];
-				for (unsigned int k = 0; k < root_hit->pos.size(); k++) {
+				for (unsigned int k = 0; k < root_hits[j]->pos.size(); k++) {
 
-					TrackerHitImpl* true_hit_data = new TrackerHitImpl();
+					//hit_events[i]->hits.back()->pos.push_back(hit_pos);
 
-					hit_pos[0] = root_hit->pos[k].X();
-					hit_pos[1] = root_hit->pos[k].Y();
-					hit_pos[2] = root_hit->pos[k].Z();
+					if (k == root_hits[j]->pos.size()/2 - 1) {
 
-					true_hit_data->setCellID0(300+j);
-					true_hit_data->setType(sensor_hit_incrs[j]);
-					true_hit_data->setPosition(hit_pos);
-					true_hit_data->setEDep(root_hit->edep[k]);
+						TrackerHitImpl* true_hit_data = new TrackerHitImpl();
 
-					sensor_hit_coll->addElement(true_hit_data);
+						hit_pos[0] = root_hits[j]->pos[k].X();
+						hit_pos[1] = root_hits[j]->pos[k].Y();
+						hit_pos[2] = root_hits[j]->pos[k].Z();
+
+						true_hit_data->setCellID0(300+j);
+						true_hit_data->setQuality(root_hits[j]->event);
+						true_hit_data->setType(root_hits[j]->pdgId[k]);
+						true_hit_data->setPosition(hit_pos);
+						true_hit_data->setEDep(root_hits[j]->edepTotal);
+
+						sensor_hit_coll->addElement(true_hit_data);
+
+					}
 				}
+				//if ((i%10 == 0) || (i == 0)) cout << root_hits[j]->event << endl;
 
-				sensor_hit_incrs[j]++;
+				hit_incrs[j]++;
 
 				delete [] hit_pos;
 			}
 
 			//loop over hits from frame
 			std::vector<float> charge_vec;
-			for (auto it = root_frame->GetHitMap().begin(); it != root_frame->GetHitMap().end(); ++it) {
+			for (auto it = root_frames[j]->GetHitMap().begin(); it != root_frames[j]->GetHitMap().end(); ++it) {
 
 				//the key contains position of hit in the format key = y*width + x
-				float x = (it->first)%root_frame->GetWidth();
-				float y = (it->first)/root_frame->GetWidth();
+				float x = (it->first)%root_frames[j]->GetWidth();
+				float y = (it->first)/root_frames[j]->GetWidth();
 				float TOT = it->second;
 
 				charge_vec.push_back(x);
@@ -239,60 +288,99 @@ int main(int argc, char* argv[]) {
 			frame_data->setChargeValues(charge_vec);
 			sensor_frame_coll->addElement(frame_data);
 			charge_vec.clear();
+
+			//loop over the primary vertices stored in the frame file
+			/*double* vertex_pos = new double[3];
+			for (unsigned int k = 0; k < root_frames[j]->GetVertex_x().size(); k++) {
+
+				TrackerHitImpl* frame_vertex = new TrackerHitImpl();
+
+				vertex_pos[0] = root_frames[j]->GetVertex_x()[k];
+				vertex_pos[1] = root_frames[j]->GetVertex_y()[k];
+				vertex_pos[2] = root_frames[j]->GetVertex_z()[k];
+
+				frame_vertex->setCellID0(300+j);
+				frame_vertex->setPosition(vertex_pos);
+
+				sensor_vertex_coll->addElement(frame_vertex);
+			}
+
+			delete [] vertex_pos;*/
 		}
+
+		/*TrackerHitImpl* test = new TrackerHitImpl();
+
+		test->setCellID0(hit_events[i]->hits.back()->sensor_ID);
+		test->setType(hit_events[i]->hits.back()->pdgId[hit_events[i]->hits.back()->pdgId.size()/2-1]);
+		test->setPosition(hit_events[i]->hits.back()->pos[hit_events[i]->hits.back()->pos.size()/2-1]);
+		test->setEDep(hit_events[i]->hits.back()->edep_total);
+
+		sensor_hit_coll->addElement(test);*/
 
 		event->addCollection(sensor_hit_coll, "true_hits_m26");
 		event->addCollection(sensor_frame_coll, "zsdata_m26");
+		//event->addCollection(sensor_vertex_coll, "MC_vertices_m26");
 
 		//write DUT true hit data collection if there are DUTs present
 		if (n_DUTs > 0) {
 
 			LCCollectionVec* DUT_hit_coll = new LCCollectionVec(LCIO::TRACKERHIT);
 			LCCollectionVec* DUT_frame_coll = new LCCollectionVec(LCIO::TRACKERDATA);
+			//LCCollectionVec* DUT_vertex_coll = new LCCollectionVec(LCIO::TRACKERHIT);
 			CellIDEncoder<TrackerDataImpl> frame_encoder_DUT(encoding_string, DUT_frame_coll);
 
 			for (int j = 0; j < n_DUTs; j++) {
 
 				TrackerDataImpl* frame_data = new TrackerDataImpl();
 
-				frame_trees[j+n_sensors]->SetBranchAddress("FramesData", &root_frame);
 				frame_trees[j+n_sensors]->GetEntry(i);
-				true_hit_trees[j+n_sensors]->SetBranchAddress("SimpleHits", &root_hit);
 
 				frame_encoder_DUT.reset();
 				frame_encoder_DUT["sensorID"] = j + 6;
 				frame_encoder_DUT["sparsePixelType"] = 2;
 				frame_encoder_DUT.setCellID(frame_data);
 
-				while (true_hit_trees[j+n_sensors]->GetEntry(DUT_hit_incrs[j]) and root_hit->run == i) {
+				while (true_hit_trees[j+n_sensors]->GetEntry(hit_incrs[j+n_sensors]) and root_hits[j+n_sensors]->run == i) {
+
+					/*hit_events[i]->hits.push_back(new TrueHit());
+					hit_events[i]->hits.back()->sensor_ID = DUT_IDs[j];
+					hit_events[i]->hits.back()->edep_total = root_hits[j]->edepTotal;
+					hit_events[i]->hits.back()->pdgId = root_hits[j]->pdgId;
+					hit_events[i]->hits.back()->edep = root_hits[j]->edep;*/
 
 					double* hit_pos = new double[3];
-					for (unsigned int k = 0; k < root_hit->pos.size(); k++) {
+					for (unsigned int k = 0; k < root_hits[j+n_sensors]->pos.size(); k++) {
 
-						TrackerHitImpl* true_hit_data = new TrackerHitImpl();
+						//hit_events[i]->hits.back()->pos.push_back(hit_pos);
 
-						hit_pos[0] = root_hit->pos[k].X();
-						hit_pos[1] = root_hit->pos[k].Y();
-						hit_pos[2] = root_hit->pos[k].Z();
+						if (k == root_hits[j+n_sensors]->pos.size()/2 - 1) {
 
-						true_hit_data->setCellID0(DUT_IDs[j]);
-						true_hit_data->setType(DUT_hit_incrs[j]);
-						true_hit_data->setPosition(hit_pos);
-						true_hit_data->setEDep(root_hit->edep[k]);
+							TrackerHitImpl* true_hit_data = new TrackerHitImpl();
 
-						DUT_hit_coll->addElement(true_hit_data);
+							hit_pos[0] = root_hits[j+n_sensors]->pos[k].X();
+							hit_pos[1] = root_hits[j+n_sensors]->pos[k].Y();
+							hit_pos[2] = root_hits[j+n_sensors]->pos[k].Z();
+
+							true_hit_data->setCellID0(DUT_IDs[j]);
+							true_hit_data->setQuality(root_hits[j+n_sensors]->event);
+							true_hit_data->setType(root_hits[j+n_sensors]->pdgId[k]);
+							true_hit_data->setPosition(hit_pos);
+							true_hit_data->setEDep(root_hits[j+n_sensors]->edepTotal);
+
+							DUT_hit_coll->addElement(true_hit_data);
+						}
 					}
 
-					DUT_hit_incrs[j]++;
+					hit_incrs[j+n_sensors]++;
 
 					delete [] hit_pos;
 				}
 
 				std::vector<float> charge_vec;
-				for (auto it = root_frame->GetHitMap().begin(); it != root_frame->GetHitMap().end(); ++it) {
+				for (auto it = root_frames[j]->GetHitMap().begin(); it != root_frames[j]->GetHitMap().end(); ++it) {
 
-					float x = (it->first)%root_frame->GetWidth();
-					float y = (it->first)/root_frame->GetWidth();
+					float x = (it->first)%root_frames[j]->GetWidth();
+					float y = (it->first)/root_frames[j]->GetWidth();
 					float TOT = it->second;
 
 					charge_vec.push_back(x);
@@ -304,10 +392,29 @@ int main(int argc, char* argv[]) {
 				frame_data->setChargeValues(charge_vec);
 				DUT_frame_coll->addElement(frame_data);
 				charge_vec.clear();
+
+
+				/*double* vertex_pos = new double[3];
+				for (unsigned int k = 0; k < root_frames[j]->GetVertex_x().size(); k++) {
+
+					TrackerHitImpl* frame_vertex = new TrackerHitImpl();
+
+					vertex_pos[0] = root_frames[j]->GetVertex_x()[k];
+					vertex_pos[1] = root_frames[j]->GetVertex_y()[k];
+					vertex_pos[2] = root_frames[j]->GetVertex_z()[k];
+
+					frame_vertex->setCellID0(DUT_IDs[j]);
+					frame_vertex->setPosition(vertex_pos);
+
+					DUT_vertex_coll->addElement(frame_vertex);
+				}
+
+				delete [] vertex_pos;*/
 			}
 
 			event->addCollection(DUT_hit_coll, "true_hits_DUT");
 			event->addCollection(DUT_frame_coll, "zsdata_DUT");
+			//event->addCollection(DUT_vertex_coll, "MC_vertices_DUT");
 		}
 
 
@@ -317,7 +424,7 @@ int main(int argc, char* argv[]) {
 		if (((i+1)%1000 == 0) || (i == 0)) std::cout << "succesfully recorded event " << i+1 << endl;
 	}
 
-	std::cout << "succesfully recorder all events\n";
+	std::cout << "succesfully recorded all events\n";
 
 	writer->flush();
 	writer->close();
@@ -329,13 +436,21 @@ int main(int argc, char* argv[]) {
 
 		delete true_hit_files[i];
 		delete frame_files[i];
+		delete root_hits[i];
+		delete root_frames[i];
 	}
+
+	/*for (int i = 0; i < n_runs; i++) {
+
+		delete hit_events[i];
+	}
+
+	delete [] hit_events;*/
 
 	delete [] true_hit_trees;
 	delete [] true_hit_files;
-
-	delete root_hit;
-	delete root_frame;
+	delete [] root_hits;
+	delete [] root_frames;
 
 	return 0;
 }


### PR DESCRIPTION
Over a summer project at the University of Goettingen were I used Allpix generated data to analyse the reconstruction capabilities of the EUTelescope framework, I have created a converter in C++ that converts the frame and hits root files into the lcio format, hence getting both the raw hit pixel information as well as the position of the true simulated hits. The converter reads in the root files containing the frames and hits, and outputs a lcio file with a collection for the true hits called "true_hits", a collection for the Mimosa26 raw data "zsdata_m26", and a collection for the DUT raw data "zsdata_DUT". The source code is located in share/EUTelConverter/RootFileConverter.cc.

The cmakelist was changed to allow for the optional building of the converter alongside Allpix if the CMake option BUILD_EUTELCONV is set to ON (by default it is set to OFF). If this option is turned on, the converter will be build under the name EUTelConverter.

An additional commit was made to fix the FEI4 single chip number of pixels to 336 in the y-direction, as per the manual p. 9 https://indico.cern.ch/event/261840/contributions/1594374/attachments/462649/641213/FE-I4B_V2.3.pdf
I don't know how to make this commit a seperate pull request, so it is included in this one.

To run the converter, the following command line options must be supplied in the following order:

"path and prefix to input root files" "path and filename of output lcio file" "number of Mimosa26 planes" "list of DUT sensor IDs"

"path and prefix to input root files" refers to the path to the folder containing the input root files, as well as their prefix. The prefix refers to the value given to /allpix/config/setOutputPrefixWithPath in the Allpix macro. If there is no prefix, i.e. this field is the path to a folder containing the root files, then this field must end with a / or it will be misinterpreted as a prefix.

"path and filename of output lcio file" refers to the path and file name of the lcio file output by the converter. Note that the file name does not need to end in .slcio, as the lcio writer adds this to the end of the filename automatically.

"number of Mimosa26 planes" refers to the number of Mimos26 planes used in the telescope setup. In the case where the telescope planes used in the setup are not Mimosa26 planes, then this filed should be set to 0, and the corresponding IDs of the telescope planes added to the list of DUT sensor IDs

"list of DUT sensor IDs" refers to a list (separated by spaces) of the sensor IDs of DUTs used in the setup. The ID corresponds to the detector ID of the chip defined in the Allpix macro.

For example, if I have run Allpix for 6 Mimosa26 sensors and 1 FEI4 single chip, with the field /allpix/config/setOutputPrefixWithPath set to “root_files/example” in the Allpix macro. I want to create a lcio file of the name “example.slcio” in the folder “lcio_files”. To run the converter I would input:
EUTelConverter       root_files/example        lcio_file/example        6        200

If there are anymore questions, I can be contacted at kl417@cam.ac.uk. My direct supervisor for this project was Tobias Bisanz.
